### PR TITLE
Exposed DATE_TRANSFORMERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,3 @@ XSBE is a novel library intended for *rapid development* of XML related python c
 It takes the approach of using lightly annotated example XML documents to act as a schema.  Using these schemas it can 
 then transform an XML document into a more friendly data structures built of dictionaries and lists such as you might 
 expect through parsing json or yaml.
-
-It's composed of two main libraries:
- - `xsbe.simple_node` Offers a reduced object model for representing XML document *content*.  See [simple_node](simple_node.md)
- - `xsbe.transform` Offers schema definition and transformer components. See [transform](transform.md)
- 

--- a/source/xsbe/transform.py
+++ b/source/xsbe/transform.py
@@ -496,6 +496,9 @@ def _create_element_transformer(element: ElementTree.Element, ignore_unexpected:
     return result
 
 
+DATE_TRANSFORMERS = [ISODateTransformer, ISOZuluDateTransformer, EmailDateTransformer]
+
+
 def _identify_text_type(text: str, result_name: Optional[str] = None) -> ValueTransformer:
     if text in BooleanTransformer.MAP:
         return BooleanTransformer(result_name=result_name)
@@ -508,7 +511,7 @@ def _identify_text_type(text: str, result_name: Optional[str] = None) -> ValueTr
             return FloatTransformer(result_name=result_name)
         return IntTransformer(result_name=result_name)
 
-    for date_type in (ISODateTransformer, ISOZuluDateTransformer, EmailDateTransformer):
+    for date_type in DATE_TRANSFORMERS:
         try:
             transformer = date_type(result_name=result_name)
             transformer.transform_from_xml(text)


### PR DESCRIPTION
Exposed DATE_TRANSFORMERS as a list of available date transformers.  The main goal is to allow customised lists of date formats.  This is a bit of a hack.  Plan to make this more generic in later versions.